### PR TITLE
fix: check error return value of os.Setenv

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -56,7 +56,10 @@ func main() {
 	// If HOME is unset or set to root (which is common in containers), set it to /tmp
 	// This ensures that the HLB Terraform provider can write credentials to ~/.hlb
 	if home := os.Getenv("HOME"); home == "" || home == "/" {
-		os.Setenv("HOME", "/tmp")
+		if err := os.Setenv("HOME", "/tmp"); err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot set HOME environment variable: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	var (


### PR DESCRIPTION
This PR fixes a linting failure in the CI workflow.

The 'errcheck' linter reported that the return value of `os.Setenv("HOME", "/tmp")` was not checked in `cmd/provider/main.go`.

Fixes #4