### PR TITLE
fix: resolve unknown field service in TestObserve

### DIFF
--- a/internal/controller/hostedloadbalancer/hostedloadbalancer_test.go
+++ b/internal/controller/hostedloadbalancer/hostedloadbalancer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"gitlab.guerraz.net/HLB/hlb-terraform-provider/hlb"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing
@@ -37,7 +38,7 @@ import (
 
 func TestObserve(t *testing.T) {
 	type fields struct {
-		service interface{}
+		hlb *hlb.Client
 	}
 
 	type args struct {
@@ -61,7 +62,7 @@ func TestObserve(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := external{service: tc.fields.service}
+			e := external{hlb: tc.fields.hlb}
 			got, err := e.Observe(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)


### PR DESCRIPTION
This PR fixes a compilation error in TestObserve by renaming the 'service' field to 'hlb' in the 'fields' struct and the 'external' struct literal, matching the definition in 'hostedloadbalancer.go'.

Fixes #7